### PR TITLE
Travis CI build update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.5
   - 1.6
+  - 1.7
   - tip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ go:
   - tip
 
 install:
+  - go get -v github.com/jteeuwen/go-bindata/...
+  - go get -v github.com/elazarl/go-bindata-assetfs/...
   - go get -v github.com/Masterminds/glide
   - cd $GOPATH/src/github.com/Masterminds/glide && git checkout tags/0.10.2 && go install && cd -
   - glide install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ go:
   - tip
 
 install:
-  - go get
+  - go get -v github.com/Masterminds/glide
+  - cd $GOPATH/src/github.com/Masterminds/glide && git checkout tags/0.10.2 && go install && cd -
+  - glide install
 
 script:
   - go build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
   - glide install
 
 script:
-  - go build
+  - make build


### PR DESCRIPTION
Improves the Travis CI build:
- Go versions 1.6 & 1.7
- Glide for dependency installation
- Uses the make build command
